### PR TITLE
"discover_inductive" instead of "discovery_inductive"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ library(bupaR)
 patients_completes <- patients[patients$registration_type == "complete", ]
 
 # Discovery with Inductive Miner
-pn <- discovery_inductive(patients_completes)
+pn <- discover_inductive(patients_completes)
 
 # This results in an auto-converted bupaR Petri net and markings
 str(pn)


### PR DESCRIPTION
In version 2.0.0 of  `pm4py`, the function to use th einductive miner is `discover_inductive()` (without the "-y") rather than `discovery_inductive`, which is what it says in the README.md.

I note that the function for the alpha miner is `discovery_alpha`, with a "-y". Should this be without the "-y"?